### PR TITLE
prevent polluting the global namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,53 +25,58 @@ use { "LinArcX/telescope-command-palette.nvim" }
 
 # Setup and Configuration
 
-First load the extension:
+First set up your commands in your Telescope config:
+
 ```lua
-require('telescope').load_extension('command_palette')
+require('telescope').setup({
+  extensions = {
+    command_palette = {
+      {"File",
+        { "entire selection (C-a)", ':call feedkeys("GVgg")' },
+        { "save current file (C-s)", ':w' },
+        { "save all files (C-A-s)", ':wa' },
+        { "quit (C-q)", ':qa' },
+        { "file browser (C-i)", ":lua require'telescope'.extensions.file_browser.file_browser()", 1 },
+        { "search word (A-w)", ":lua require('telescope.builtin').live_grep()", 1 },
+        { "git files (A-f)", ":lua require('telescope.builtin').git_files()", 1 },
+        { "files (C-f)",     ":lua require('telescope.builtin').find_files()", 1 },
+      },
+      {"Help",
+        { "tips", ":help tips" },
+        { "cheatsheet", ":help index" },
+        { "tutorial", ":help tutor" },
+        { "summary", ":help summary" },
+        { "quick reference", ":help quickref" },
+        { "search help(F1)", ":lua require('telescope.builtin').help_tags()", 1 },
+      },
+      {"Vim",
+        { "reload vimrc", ":source $MYVIMRC" },
+        { 'check health', ":checkhealth" },
+        { "jumps (Alt-j)", ":lua require('telescope.builtin').jumplist()" },
+        { "commands", ":lua require('telescope.builtin').commands()" },
+        { "command history", ":lua require('telescope.builtin').command_history()" },
+        { "registers (A-e)", ":lua require('telescope.builtin').registers()" },
+        { "colorshceme", ":lua require('telescope.builtin').colorscheme()", 1 },
+        { "vim options", ":lua require('telescope.builtin').vim_options()" },
+        { "keymaps", ":lua require('telescope.builtin').keymaps()" },
+        { "buffers", ":Telescope buffers" },
+        { "search history (C-h)", ":lua require('telescope.builtin').search_history()" },
+        { "paste mode", ':set paste!' },
+        { 'cursor line', ':set cursorline!' },
+        { 'cursor column', ':set cursorcolumn!' },
+        { "spell checker", ':set spell!' },
+        { "relative number", ':set relativenumber!' },
+        { "search highlighting (F12)", ':set hlsearch!' },
+      }
+    }
+  }
+})
 ```
 
-And then declare the `CpMenu` items like this:
+And then load the extension:
 
 ```lua
-CpMenu = {
-  {"File",
-    { "entire selection (C-a)", ':call feedkeys("GVgg")' },
-    { "save current file (C-s)", ':w' },
-    { "save all files (C-A-s)", ':wa' },
-    { "quit (C-q)", ':qa' },
-    { "file browser (C-i)", ":lua require'telescope'.extensions.file_browser.file_browser()", 1 },
-    { "search word (A-w)", ":lua require('telescope.builtin').live_grep()", 1 },
-    { "git files (A-f)", ":lua require('telescope.builtin').git_files()", 1 },
-    { "files (C-f)",     ":lua require('telescope.builtin').find_files()", 1 },
-  },
-  {"Help",
-    { "tips", ":help tips" },
-    { "cheatsheet", ":help index" },
-    { "tutorial", ":help tutor" },
-    { "summary", ":help summary" },
-    { "quick reference", ":help quickref" },
-    { "search help(F1)", ":lua require('telescope.builtin').help_tags()", 1 },
-  },
-  {"Vim",
-    { "reload vimrc", ":source $MYVIMRC" },
-    { 'check health', ":checkhealth" },
-    { "jumps (Alt-j)", ":lua require('telescope.builtin').jumplist()" },
-    { "commands", ":lua require('telescope.builtin').commands()" },
-    { "command history", ":lua require('telescope.builtin').command_history()" },
-    { "registers (A-e)", ":lua require('telescope.builtin').registers()" },
-    { "colorshceme", ":lua require('telescope.builtin').colorscheme()", 1 },
-    { "vim options", ":lua require('telescope.builtin').vim_options()" },
-    { "keymaps", ":lua require('telescope.builtin').keymaps()" },
-    { "buffers", ":Telescope buffers" },
-    { "search history (C-h)", ":lua require('telescope.builtin').search_history()" },
-    { "paste mode", ':set paste!' },
-    { 'cursor line', ':set cursorline!' },
-    { 'cursor column', ':set cursorcolumn!' },
-    { "spell checker", ':set spell!' },
-    { "relative number", ':set relativenumber!' },
-    { "search highlighting (F12)", ':set hlsearch!' },
-  }
-}
+require('telescope').load_extension('command_palette')
 ```
 
 The idea is that you declare some **categories**("Help", "Vim", etc..) and inside each category, you define your commands.
@@ -88,7 +93,7 @@ If you're working on different projects and want to have special key_bindings pe
 
 ```lua
 
-table.insert(CpMenu,
+table.insert(require('command_palette').CpMenu,
   {"Dap",
     { "pause", ":lua require'dap'.pause()" },
     { "step into", ":lua require'dap'.step_into()" },

--- a/lua/command_palette.lua
+++ b/lua/command_palette.lua
@@ -1,0 +1,5 @@
+local M = {}
+
+M.CpMenu = {}
+
+return M

--- a/lua/telescope/_extensions/command_palette.lua
+++ b/lua/telescope/_extensions/command_palette.lua
@@ -7,7 +7,12 @@ local action_state = require "telescope.actions.state"
 local entry_display = require('telescope.pickers.entry_display')
 
 local categories
-CpMenu = CpMenu or {}
+local CpMenu = require('command_palette').CpMenu
+
+local function setup(cpMenu)
+  require('command_palette').CpMenu = cpMenu or {}
+  CpMenu = require('command_palette').CpMenu
+end
 
 function themes.vscode(opts)
   opts = opts or {}
@@ -160,6 +165,7 @@ local function run()
 end
 
 return require('telescope').register_extension {
+  setup = setup,
   exports = {
     -- Default when to argument is given, i.e. :Telescope command_palette
     command_palette = run,


### PR DESCRIPTION
Moves `CpMenu` to it's own module to prevent polluting the global namespace

Fixes #4 